### PR TITLE
chore: fix the docker command to setup the sql services

### DIFF
--- a/docs/contributing/contributing-for-developers.md
+++ b/docs/contributing/contributing-for-developers.md
@@ -104,7 +104,7 @@ VS Code will now build the Docker container and open the Webstudio project insid
     * Navigate to the .devcontainer folder and execute the SQL setup with Docker Compose:
 
     ```bash
-    docker-compose up -d pg
+    docker-compose up -d rest
     ```
 
     * Go to the project root directory and run the following command to create the database schema:

--- a/docs/contributing/contributing-for-developers.md
+++ b/docs/contributing/contributing-for-developers.md
@@ -104,7 +104,7 @@ VS Code will now build the Docker container and open the Webstudio project insid
     * Navigate to the .devcontainer folder and execute the SQL setup with Docker Compose:
 
     ```bash
-    docker-compose up -d rest
+    docker compose  up -d
     ```
 
     * Go to the project root directory and run the following command to create the database schema:


### PR DESCRIPTION
With adding `postgrest` service for loading data for the builder now. The local setup needs the `postgrest` service to run at `3000` post. Or else to app fails to load data.

https://github.com/webstudio-is/webstudio/pull/3758/files#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1R44
PS: The old service name `pg` too doesn't exist. But now `docker-compose up -d rest` will start the database service too. 

One more thing, it might be a version related thing or something. The `docker-compose` doesn't work in my macos. I should use with `docker compose` instead.