### PR TITLE
added link to custom font documentation on main 'how to' page

### DIFF
--- a/docs/university/how-tos/README.md
+++ b/docs/university/how-tos/README.md
@@ -27,3 +27,7 @@
 {% content-ref url="using-filters-to-dynamically-display-content.md" %}
 [using-filters-to-dynamically-display-content.md](using-filters-to-dynamically-display-content.md)
 {% endcontent-ref %}
+
+{% content-ref url="how-to-use-custom-fonts.md" %}
+[how-to-use-custom-fonts.md](how-to-use-custom-fonts.md)
+{% endcontent-ref %}


### PR DESCRIPTION
Added missing link so the custom font documentation is now linked within the menu.